### PR TITLE
Fix filename split

### DIFF
--- a/isoread
+++ b/isoread
@@ -131,7 +131,7 @@ extract_iso()
             #
             # Strip leading fields
             #
-            local FILE=`echo $LINE | cut -d" " -f12`
+            local FILE=${LINE##* }
 
             #
             # $ISOINFO to leave .. as a file sometimes


### PR DESCRIPTION
Keeping really only last field, not hardcoded value to 12 which can be wrong in some cases.